### PR TITLE
feat: add enter key support to email signup/login section

### DIFF
--- a/lark-ui/src/routes/login/+page.svelte
+++ b/lark-ui/src/routes/login/+page.svelte
@@ -412,6 +412,7 @@
       {#if requestingOTP} 
         <form
           class="flex flex-col w-full items-center justify-center h-full mt-6"
+          onsubmit={(e) => { e.preventDefault(); sendOTP(); }}
         >
           <div class="flex flex-col gap-[1.5vh] w-full max-w-[400px]">
             <label
@@ -432,7 +433,7 @@
               placeholder="wdaniel@gmail.com"
             />
 
-            <Button label={isSubmitting ? "sending..." : "Next →"} disabled={isSubmitting} onclick={sendOTP}/>
+            <Button label={isSubmitting ? "sending..." : "Next →"} disabled={isSubmitting} type="submit"/>
 
             {#if error}
               <p


### PR DESCRIPTION
Makes pressing enter on the login/signup form send the OTP code & progress forwards instead of just adding the email parameter to the url and doing nothing else

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved OTP request submission to use standard form submission handling, ensuring consistent validation and error handling behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->